### PR TITLE
Add winfilemanager example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # gf2
+
+## winfilemanager
+
+A simple file manager example for Windows using the [gocui](https://github.com/jroimartin/gocui) library.
+
+### Keybindings
+
+- `Ctrl+C` - Quit the application.
+
+### Build
+
+Run the following command from the repository root:
+
+```sh
+go build -o winfilemanager.exe ./cmd/winfilemanager
+```
+
+### Running on Windows
+
+Ensure Go is installed. Build the application as above and execute `winfilemanager.exe` from a command prompt. The UI shows a single view with the message "Press Ctrl+C to quit". Use the keybinding to exit.
+

--- a/cmd/winfilemanager/main.go
+++ b/cmd/winfilemanager/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jroimartin/gocui"
+)
+
+func layout(g *gocui.Gui) error {
+	maxX, maxY := g.Size()
+	if v, err := g.SetView("main", maxX/2-20, maxY/2-1, maxX/2+20, maxY/2+1); err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		fmt.Fprintln(v, "Press Ctrl+C to quit")
+	}
+	return nil
+}
+
+func quit(g *gocui.Gui, v *gocui.View) error {
+	return gocui.ErrQuit
+}
+
+func main() {
+	g, err := gocui.NewGui(gocui.OutputNormal)
+	if err != nil {
+		log.Panicln(err)
+	}
+	defer g.Close()
+
+	g.SetManagerFunc(layout)
+
+	if err := g.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
+		log.Panicln(err)
+	}
+
+	if err := g.MainLoop(); err != nil && err != gocui.ErrQuit {
+		log.Panicln(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module gf2
+
+go 1.24.3


### PR DESCRIPTION
## Summary
- initialize Go module
- add gocui example under `cmd/winfilemanager`
- document build instructions and keybindings for Windows

## Testing
- `go vet ./...` *(fails: no module for github.com/jroimartin/gocui)*
- `go build ./cmd/winfilemanager` *(fails: no module for github.com/jroimartin/gocui)*

------
https://chatgpt.com/codex/tasks/task_e_686a0dd968088322b38eb8281f163702